### PR TITLE
webpack 2 and config improvments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    "es2015"
+    "es2015-native-modules"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "dependencies": {
     "babel-core": "6.8.0",
     "babel-loader": "6.2.4",
-    "babel-preset-es2015": "6.6.0",
+    "babel-preset-es2015-native-modules": "^6.6.0",
     "express": "4.13.4",
     "rimraf": "2.5.2",
     "start-server-webpack-plugin": "2.0.1",
-    "webpack": "1.13.0"
+    "webpack": "^2.1.0-beta"
   },
   "devDependencies": {
     "npm-install-webpack-plugin": "3.1.1"

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,5 @@
 import express from "express";
-
-function getApp() {
-  return require("./app").default;
-}
+import app from "./app";
 
 if (module.hot) {
   module.hot.accept("./app", function() {
@@ -15,7 +12,7 @@ if (module.hot) {
 }
 
 export default express()
-  .use((req, res) => getApp().handle(req, res))
+  .use((req, res) => app.handle(req, res))
   .listen(3000, function(err) {
     if (err) {
       console.error(err);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
   module: {
     loaders: [
       {
-        exclude: /node_modules/,
         loader: "babel",
         query: { cacheDirectory: true },
         test: /\.js$/,
@@ -45,6 +44,7 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new StartServerPlugin(),
+    new webpack.NamedModulesPlugin(),
   ],
 
   target: "async-node",


### PR DESCRIPTION
webpack 2 supports HMR for ES6 imports, so the app import can be simplified:

``` diff
-
-function getApp() {
-  return require("./app").default;
-}
+import app from "./app";
```

I also added the `NamedModulesPlugin` which makes update messages look nicer:

``` text
[HMR] Updated modules:
[HMR]  - ./src/middleware/api.js
[HMR]  - ./src/app.js
[HMR] Update applied.
```

instead of

``` text
[HMR] Updated modules:
[HMR]  - 5
[HMR]  - 1
[HMR] Update applied.
```
