### PR TITLE
rm default in require; upgrade to webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "express": "^4.14.0",
     "rimraf": "^2.5.4",
     "start-server-webpack-plugin": "^2.0.1",
-    "webpack": "^2.1.0-beta"
+    "webpack": "^2.2.1"
   },
   "devDependencies": {
     "npm-install-webpack-plugin": "^4.0.4"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 var NpmInstallPlugin = require("npm-install-webpack-plugin");
-var StartServerPlugin = require("start-server-webpack-plugin").default;
+var StartServerPlugin = require("start-server-webpack-plugin");
 var webpack = require("webpack");
 
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
   module: {
     loaders: [
       {
-        loader: "babel",
+        loader: "babel-loader",
         query: { cacheDirectory: true },
         test: /\.js$/,
       },
@@ -44,7 +44,7 @@ module.exports = {
     new StartServerPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
   ],
 
   target: "async-node",


### PR DESCRIPTION
fixes `TypeError: StartServerPlugin is not a constructor`