### PR TITLE
Fixed bugs in webpack.config.js and added support for vs code editor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceRoot}/node_modules/webpack/bin/webpack.js",
+            "args": ["--watch"],
+            "cwd": "${workspaceRoot}"
+   
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Process",
+            "address": "localhost",
+            "port": 5858
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
-    "babel-preset-es2015": "6.14.0",
+    "babel-preset-es2015": "6.24.0",
     "express": "^4.14.0",
     "rimraf": "^2.5.4",
     "start-server-webpack-plugin": "^2.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 var NpmInstallPlugin = require("npm-install-webpack-plugin");
-var StartServerPlugin = require("start-server-webpack-plugin").default;
+var StartServerPlugin = require("start-server-webpack-plugin");
 var webpack = require("webpack");
 
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
   module: {
     loaders: [
       {
-        loader: "babel",
+        loader: "babel-loader",
         query: { cacheDirectory: true },
         test: /\.js$/,
       },
@@ -44,7 +44,7 @@ module.exports = {
     new StartServerPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
   ],
 
   target: "async-node",


### PR DESCRIPTION
1. removed .default from require of "start-server-webpack-plugin"
2. changed "babel" to "babel-loader" to conform to new requirements
3. Changed to NoErrorsPlugin because of deprecated  NoEmitOnErrorsPlugin

Also added launch.json for VS Code editor