### PR TITLE
Update webpack to latest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     [
-      "es2015",
+      "latest",
       { "modules": false }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "node": ">=4.2.0"
   },
   "dependencies": {
-    "babel-core": "^6.14.0",
-    "babel-loader": "^6.2.5",
-    "babel-preset-es2015": "6.14.0",
-    "express": "^4.14.0",
-    "rimraf": "^2.5.4",
-    "start-server-webpack-plugin": "^2.0.1",
-    "webpack": "^2.1.0-beta"
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.0.0",
+    "babel-preset-latest": "^6.24.1",
+    "express": "^4.15.3",
+    "rimraf": "^2.6.1",
+    "start-server-webpack-plugin": "^2.2.0",
+    "webpack": "^2.6.1"
   },
   "devDependencies": {
     "npm-install-webpack-plugin": "^4.0.4"

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,9 @@
 import express from "express";
-import app from "./app";
+let app = require("./app").default;
 
 if (module.hot) {
   module.hot.accept("./app", function() {
+    app = require("./app").default;
     console.log("🔁  HMR Reloading `./app`...");
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 var NpmInstallPlugin = require("npm-install-webpack-plugin");
-var StartServerPlugin = require("start-server-webpack-plugin").default;
+var StartServerPlugin = require("start-server-webpack-plugin");
 var webpack = require("webpack");
+var path = require("path");
 
 module.exports = {
   devtool: "inline-sourcemap",
@@ -20,7 +21,7 @@ module.exports = {
   module: {
     loaders: [
       {
-        loader: "babel",
+        loader: "babel-loader",
         query: { cacheDirectory: true },
         test: /\.js$/,
       },
@@ -37,14 +38,14 @@ module.exports = {
     devtoolModuleFilenameTemplate: "[absolute-resource-path]",
     filename: "[name].js",
     libraryTarget: "commonjs2",
-    path: "./build/server",
+    path: path.resolve(__dirname, "./build/server"),
   },
 
   plugins: [
     new StartServerPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
   ],
 
   target: "async-node",


### PR DESCRIPTION
Fixes:
```bash
WARNING in webpack: Using NoErrorsPlugin is deprecated.
Use NoEmitOnErrorsPlugin instead.
```
```bash
ERROR in multi webpack/hot/poll?1000 ./src/server.js
Module not found: Error: Can't resolve 'babel' in 'webpack-hot-server-example'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed
 @ multi webpack/hot/poll?1000 ./src/server.js
```